### PR TITLE
Fixed multiple Cytron Override Issue

### DIFF
--- a/src/Cytron_SmartDriveDuo.cpp
+++ b/src/Cytron_SmartDriveDuo.cpp
@@ -31,7 +31,6 @@ Cytron_SmartDriveDuo::Cytron_SmartDriveDuo(int mode, int in1Pin, int in2Pin, int
   pinMode(_in2Pin, OUTPUT);
 }
 
-SoftwareSerial* MDDSSerial;
 boolean hardwareSerial;
 Cytron_SmartDriveDuo::Cytron_SmartDriveDuo(int mode, int txPin, uint32_t baudrate)
 {

--- a/src/Cytron_SmartDriveDuo.h
+++ b/src/Cytron_SmartDriveDuo.h
@@ -30,6 +30,7 @@ class Cytron_SmartDriveDuo
     void control(signed int motorLeftSpeed, signed int motorRightSpeed);
     
   private:
+    SoftwareSerial* MDDSSerial;
   	uint8_t _mode;
   	uint8_t _rc1Pin, _rc2Pin;
   	uint8_t _an1Pin, _an2Pin, _in1Pin, _in2Pin;


### PR DESCRIPTION
The Cytron Smart Drive Duo class was using the same software serial object, due to which only the newest initialized object was being controlled and the previously initialized objects were not being taken into account when updating motors on the other Cytron MDDS30A boards. The same was fixed by moving the MDDSSerial object from the CPP file to the list of private objects in the Cytron_SmartDriveDuo class by me and [shahjash01](https://github.com/shahjash01)